### PR TITLE
Fix checkbox (Firefox)

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -143,7 +143,7 @@
     },
     "input/checkbox/hidden": {
         "scope": "teambit.base-ui",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "mainFile": "index.ts",
         "rootDir": "src/input/checkbox/hidden"
     },
@@ -155,7 +155,7 @@
     },
     "input/checkbox/label": {
         "scope": "teambit.base-ui",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "mainFile": "index.ts",
         "rootDir": "src/input/checkbox/label"
     },

--- a/src/input/checkbox/hidden/hidden-checkbox.module.scss
+++ b/src/input/checkbox/hidden/hidden-checkbox.module.scss
@@ -1,17 +1,28 @@
 .hidden {
-	pointer-events: none;
-	overflow: hidden;
-	// opacity hinder accessibility. (consider replacing in the future)
-	opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
+  // opacity hinder accessibility. (consider replacing in the future)
+  opacity: 0;
 
-	// minimize, without removing from dom:
-	outline: 0;
-	// -1px to compensate for input's size
-	margin: 0 -1px 0 0;
-	border: 0;
-	width: 1px;
-	height: 1px;
-	background: none;
-	padding: 0;
+  // pos: abs removes the element from the normal flow,
+  // collapsing the space it occupies,
+  // without hindering screen readers, and focus.
+  // (this is important in Firefox where checkbox takes a min size of 4px)
+  position: absolute;
 
+  // minimize, without removing from dom:
+  outline: 0;
+  margin: 0 -1px 0 0; // compensate the input's size
+  border: 0;
+  width: 1px;
+  height: 1px;
+  background: none;
+  padding: 0;
 }
+
+// rules not to apply,
+// as screen readers will ignore them:
+
+// visibility: hidden;
+// display: none;
+// width: 0; height: 0;

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -53,7 +53,6 @@
         "react-onclickoutside": "^6.9.0",
         "react-scripts": "3.4.1",
         "react-slick": "^0.27.0",
-        "resize-observer-polyfill": "^1.5.1",
         "typescript": "^3.8.3",
         "url-parse": "1.5.1",
         "use-deep-compare": "1.1.0"


### PR DESCRIPTION
- collapse the space of the hidden input by using `position: absolute`

<img width="201" alt="Screen Shot 2022-02-07 at 15 10 40" src="https://user-images.githubusercontent.com/5400361/153184407-fc9e21d8-d754-44d2-ae0b-6f479912abb1.png">

